### PR TITLE
Use Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
   <url>http://marfgamer.net/JRakNet</url>
 
   <properties>
-    <maven.compiler.source>1.9</maven.compiler.source>
-    <maven.compiler.target>1.9</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <github.global.server>github</github.global.server>
   </properties>


### PR DESCRIPTION
Java 9 is still relatively new. For compatibility reasons, java 8 should be used to compile the source (maybe even 7)