### PR TITLE
Update Packet.java

### DIFF
--- a/src/main/java/com/whirvis/jraknet/Packet.java
+++ b/src/main/java/com/whirvis/jraknet/Packet.java
@@ -190,7 +190,7 @@ public class Packet {
 	private byte[] readCFU(int length) {
 		byte[] data = new byte[length];
 		for (int i = 0; i < data.length; i++) {
-			data[0] = this.readCFUByte();
+			data[i] = this.readCFUByte();
 		}
 		return data;
 	}


### PR DESCRIPTION
readCFU(): BUG fixed
This method is invoked when an IP address is read out from the wire.